### PR TITLE
Fix a typo in finite.jl when evaluating F1 score with confusion matrix

### DIFF
--- a/src/finite.jl
+++ b/src/finite.jl
@@ -500,7 +500,7 @@ const FScoreType = API.FussyMeasure{<:API.RobustMeasure{<:_FScore}}
 
 # Allow callable on confusion matrices:
 (measure::FScoreType)(cm::ConfusionMatrices.ConfusionMatrix) =
-        ConfusionMatrices.fscore(cm, measures.beta)
+        ConfusionMatrices.fscore(cm, measure.beta)
 
 # these traits will be inherited by `FScore`:
 @trait(


### PR DESCRIPTION
`measures.beta` should be `measure.beta`.

This PR will fix the following error:
```julia
using MLJ
yt = Int.(rand(100) .> 0.5)
yp = Int.(rand(100) .> 0.5)
cm = confmat(yp, yt)
f1 = f1score(cm)
```
Errored with
```
ERROR: type #measures has no field beta
Stacktrace:
 [1] getproperty(x::Function, f::Symbol)
   @ Base ./Base.jl:37
 [2] (::StatisticalMeasuresBase.FussyMeasure{…})(cm::StatisticalMeasures.ConfusionMatrices.ConfusionMatrix{…})
   @ StatisticalMeasures ~/.julia/packages/StatisticalMeasures/NoDLI/src/finite.jl:502
 [3] top-level scope
   @ REPL[6]:1
Some type information was truncated. Use `show(err)` to see complete types.
```