### PR TITLE
performance optimizations for Confusion Matrix

### DIFF
--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -204,7 +204,7 @@ See also [`$CM.confmat`](@ref).
 """
 function ConfusionMatrix(
     m,
-    dic::AbstractDict{L,I};
+    dic::OrderedCollections.FrozenLittleDict{L, I};
     checks=true,
     ordered=false,
     ) where {L,I<:Integer}
@@ -222,12 +222,16 @@ function ConfusionMatrix(
             "to be integers from 1 to $N. "
         ))
     end
-    if dic isa OrderedCollections.FrozenLittleDict
-        index_given_level = dic
-    else
-        index_given_level = freeze(dic)
-    end
-    ConfusionMatrix{N,ordered,L}(m, index_given_level)
+    
+    ConfusionMatrix{N,ordered,L}(m, dic)
+end
+function ConfusionMatrix(
+    m,
+    dic::AbstractDict;
+    checks=true,
+    ordered=false,
+    ) 
+    ConfusionMatrix(m, freeze(dic); checks, ordered)
 end
 
 """

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -185,8 +185,8 @@ ordered confusion matrices, see [`$CM.confmat`](@ref).
 
 """
 struct ConfusionMatrix{N,O,L}
-    mat::Matrix{Int}
-    index_given_level::LittleDict{L, Int, NTuple{N,L}, NTuple{N,Int}}
+    mat::Matrix{<:Integer}
+    index_given_level::LittleDict{L, I, NTuple{N,L}, NTuple{N,I}} where I<:Integer
 end
 
 """

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -251,7 +251,7 @@ function ConfusionMatrix(m, levels::AbstractVector{L}; ordered=false, checks=tru
         ))
     end
     index_given_level =
-        LittleDict{L, Int, Vector{L}, Vector{Int}}(levels, eachindex(levels)) |> freeze
+        LittleDict{L, Int, Vector{L}, Vector{Int}}(levels, eachindex(levels))
     ConfusionMatrix(m, index_given_level; ordered, checks=false)
 end
 
@@ -533,15 +533,13 @@ end
 
 
 # ## Final method to do the computation
-
-function _confmat(ŷ, y, indexer, levels, ordered)
+function _confmat(ŷ, y, indexer::F, levels, ordered) where F
     nc = length(levels)
     cmat = zeros(Int, nc, nc)
     @inbounds for i in eachindex(y)
         (ismissing(y[i]) || ismissing(ŷ[i])) && continue
         cmat[get(indexer, ŷ[i]), get(indexer, y[i])] += 1
     end
-    index_given_level = LittleDict(c => get(indexer, c) for c in levels) |> freeze
     return ConfusionMatrix(cmat, levels; ordered, checks=false)
 end
 

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -496,7 +496,8 @@ function confmat(ŷ, y, _levels, _perm, rev)
     perm = permutation(_perm,  rev, levels)
 
     levels = apply(perm, levels)
-    indexer = LittleDict(levels[i] => i for i in eachindex(levels)) |> freeze
+    L = eltype(levels)
+    indexer = LittleDict{L, Int, Vector{L}, Vector{Int}}(levels, eachindex(levels)) |> freeze
     _confmat(ŷ, y, indexer, levels, ordered)
 end
 

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -208,8 +208,8 @@ function ConfusionMatrix(
     checks=true,
     ordered=false,
     ) where {L,I<:Integer,N}
-    s = size(m)
     if checks
+        s = size(m)
         N == s[1] == s[2] || throw(ArgumentError("Expected a square matrix."))
         N > 1 || throw(ArgumentError("Expected a matrix of size ≥ 2x2."))
         length(unique(keys(dic))) == N || throw(ArgumentError(
@@ -221,7 +221,6 @@ function ConfusionMatrix(
             "to be integers from 1 to $N. "
         ))
     end
-    
     ConfusionMatrix{N,ordered,L}(m, dic)
 end
 function ConfusionMatrix(

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -204,14 +204,13 @@ See also [`$CM.confmat`](@ref).
 """
 function ConfusionMatrix(
     m,
-    dic::OrderedCollections.FrozenLittleDict{L, I};
+    dic::LittleDict{L, I, NTuple{N,L}, NTuple{N,I}};
     checks=true,
     ordered=false,
-    ) where {L,I<:Integer}
+    ) where {L,I<:Integer,N}
     s = size(m)
-    N = s[1]
     if checks
-        N == s[2] || throw(ArgumentError("Expected a square matrix."))
+        N == s[1] == s[2] || throw(ArgumentError("Expected a square matrix."))
         N > 1 || throw(ArgumentError("Expected a matrix of size ≥ 2x2."))
         length(unique(keys(dic))) == N || throw(ArgumentError(
         "Expected dictionary with $N unique keys (levels) as "*


### PR DESCRIPTION
This optimizes `confmat` in two ways:
- make `_confmat` type stable by adding a type parameter for the `indexer` function.
- remove a redundant `freeze` call in `ConfusionMatrix`
- remove an unused definition of `index_given_levels` in `_confmat`

The runtime for `confmat` is reduced by at least 10 times.