### PR TITLE
Fix `can_report_unaggregated` trait for LogScore and BrierScore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatisticalMeasures"
 uuid = "a19d573c-0a75-4610-95b3-7071388c7541"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -298,7 +298,7 @@ register(
     "balanced_accuracy",
     "bacc",
     "bac",
-    "probability_of_correct_classification",
+    "Ppprobability_of_correct_classification",
 )
 
 const BalancedAccuracyDoc = docstring(

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -293,7 +293,13 @@ const BalancedAccuracyType = API.FussyMeasure{
     human_name="balanced accuracy",
 )
 
-register(BalancedAccuracy, "balanced_accuracy", "bacc", "bac")
+register(
+    BalancedAccuracy,
+    "balanced_accuracy",
+    "bacc",
+    "bac",
+    "probability_of_correct_classification",
+)
 
 const BalancedAccuracyDoc = docstring(
     "BalancedAccuracy(; adjusted=false)",

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -228,6 +228,7 @@ const LogLossType = API.FussyMeasure{<:API.RobustMeasure{<:_LogLossType}}
 @trait(
     _LogLossType,
     consumes_multiple_observations=true,
+    can_report_unaggregated=true,
     kind_of_proxy=LearnAPI.Distribution(),
     # observation_scitype depends on distribution type
     observation_scitype = Union{Missing,Finite,Infinite},
@@ -398,6 +399,7 @@ const BrierLossType = API.FussyMeasure{<:API.RobustMeasure{<:_BrierLossType}}
 @trait(
     _BrierLossType,
     consumes_multiple_observations=true,
+    can_report_unaggregated=true,
     kind_of_proxy=LearnAPI.Distribution(),
     # observation_scitype depends on distribution type
     observation_scitype = Union{Missing,Finite,Infinite},


### PR DESCRIPTION
To resolve #14. 

Also closes #15.