### PR TITLE
For a 0.1.6 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatisticalMeasures"
 uuid = "a19d573c-0a75-4610-95b3-7071388c7541"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -298,7 +298,7 @@ register(
     "balanced_accuracy",
     "bacc",
     "bac",
-    "Ppprobability_of_correct_classification",
+    "probability_of_correct_classification",
 )
 
 const BalancedAccuracyDoc = docstring(


### PR DESCRIPTION
Fix name of alias, `probability_of_correct_classification`