### PR TITLE
Define balanced accuracy for confusion matrices

### DIFF
--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -636,6 +636,7 @@ for f in [
     :accuracy,
     :kappa,
     :matthews_correlation,
+    :balanced_accuracy
     ]
     quote
         $f(cm::ConfusionMatrix, args...; kwargs...) =

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -243,6 +243,13 @@ const multitarget_accuracy = MultitargetAccuracy()
 struct _BalancedAccuracy
     adjusted::Bool
 end
+BalancedAccuracy(adjusted) =
+    _BalancedAccuracy(adjusted) |> robust_measure |> fussy_measure
+BalancedAccuracy(; adjusted=false) = BalancedAccuracy(adjusted)
+
+const BalancedAccuracyType = API.FussyMeasure{
+    <:API.RobustMeasure{<:_BalancedAccuracy}
+}
 
 nlevels(y) = length(unique(skipmissing(y)))
 nlevels(y::CategoricalArrays.CatArrOrSub) = length(CategoricalArrays.levels(y))
@@ -276,14 +283,6 @@ function (m::_BalancedAccuracy)(ŷ, y, weights=nothing)
     score = Accuracy()(ŷ, y, weights, balancing_class_weights)
     return m.adjusted ? adjust_bac(score, nlevels(y)) : score
 end
-
-BalancedAccuracy(adjusted) =
-    _BalancedAccuracy(adjusted) |> robust_measure |> fussy_measure
-BalancedAccuracy(; adjusted=false) = BalancedAccuracy(adjusted)
-
-const BalancedAccuracyType = API.FussyMeasure{
-    <:API.RobustMeasure{<:_BalancedAccuracy}
-}
 
 @fix_show BalancedAccuracy::BalancedAccuracyType
 

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -317,6 +317,8 @@ Setting `adjusted=true` rescales the score in the way prescribed in [L. Mosley
 imbalance problem. PhD thesis, Iowa State University. In the binary case, the adjusted
 balanced accuracy is also known as *Youden’s J statistic*, or *informedness*.
 
+Can also be called on a confusion matrix. See [`ConfusionMatrix`](@ref).
+
 $INVARIANT_LABEL
 """,
 scitype=DOC_FINITE)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -193,6 +193,19 @@ end
 """$(docstring("Functions.accuracy", the=true))"""
 accuracy(m) =  sum(diag(m)) / sum(m)
 
+"""$(docstring("Functions.balanced_accuracy", the=true))"""
+function balanced_accuracy(m)
+    # the number of correctly classified observations per class
+    d = diag(m)
+    total = 0.0
+    for i in eachindex(d)
+        # calculate accuracy for each class
+        total += d[i] / sum(view(m, :, i))
+    end
+    # return the averaged accuracy
+    return total/length(d)
+end
+
 """$(docstring("Functions.kappa"))"""
 function kappa(m)
     C = size(m, 1)

--- a/test/finite.jl
+++ b/test/finite.jl
@@ -74,7 +74,7 @@ end
     sk_bacc = 0.17493386243386244 # note: sk-learn reverses ŷ and y
     @test bacc(ŷ, y) ≈ sk_bacc
     sk_adjusted_bacc =  -0.10008818342151675
-    @test BalancedAccuracy(adjusted=true)(ŷ, y) ≈ sk_adjusted_bacc
+    @test BalancedAccuracy(adjusted=true)(ŷ, y) ≈ BalancedAccuracy(adjusted=true)(CM.confmat(ŷ, y)) ≈ sk_adjusted_bacc
     sk_bacc_w = 0.1581913163016446
     @test bacc(ŷ, y, w) ≈ sk_bacc_w
     sk_adjusted_bacc_w = -0.1224115782644738


### PR DESCRIPTION
This adds a dispatch for calculating balanced accuracy from a confusion matrix.