### PR TITLE
Fixing typo in RSquared documentation

### DIFF
--- a/src/continuous.jl
+++ b/src/continuous.jl
@@ -530,7 +530,7 @@ const RSquaredDoc = docstring(
 """
 Specifically, return the value of
 
-``1 - \\frac{∑ᵢ (ŷ_i- y_i)^2}{∑ᵢ ȳ - y_i)^2},``
+``1 - \\frac{∑ᵢ (ŷ_i- y_i)^2}{∑ᵢ (ȳ - y_i)^2}``
 
 where ``ȳ`` denote the mean of the ``y_i``. Also known as R-squared or the coefficient
 of determination, the `R²` coefficients is suitable for interpreting linear regression


### PR DESCRIPTION
<img width="125" height="46" alt="image" src="https://github.com/user-attachments/assets/7d4c7ffc-030f-4bec-9880-0c439cc78d89" />

The `RSquared` formula is shown in that way in the current documentation. This PR fixes it.