### PR TITLE
Support CategoricalArrays@1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ LossFunctionsExt = "LossFunctions"
 ScientificTypesExt = "ScientificTypes"
 
 [compat]
-CategoricalArrays = "0.10"
+CategoricalArrays = "0.10, 1"
 CategoricalDistributions = "0.1"
 Distributions = "0.25"
 LearnAPI = "0.2, 1"


### PR DESCRIPTION
It seems CompatHelper was disabled due to inactivity in this repo as well.

A new release with CategoricalArrays@1 support is required for https://github.com/JuliaAI/MLJBase.jl/pull/1006.

The PR itself requires a new release of CategoricalDistributions which includes https://github.com/JuliaAI/CategoricalDistributions.jl/pull/75