### PR TITLE
Support CategoricalArrays 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,8 +26,8 @@ LossFunctionsExt = "LossFunctions"
 ScientificTypesExt = "ScientificTypes"
 
 [compat]
-CategoricalArrays = "0.10"
-CategoricalDistributions = "0.1"
+CategoricalArrays = "1"
+CategoricalDistributions = "0.2"
 Distributions = "0.25"
 LearnAPI = "0.2, 1"
 LossFunctions = "0.10, 0.11, 1"

--- a/docs/make_tools.jl
+++ b/docs/make_tools.jl
@@ -74,9 +74,9 @@ consume (given by the value of the trait,
 
 Measures are not strict about data conforming to the declared observation scitype. For
 example, where `OrderedFactor{2}` is expected, `Finite{2}` will work, and in fact most
-eltypes will work, so long as there are only two classes. However, you may get warnings
-that mitigate possible misinterpretations of results (e.g., about which class is the
-"positive" one). Some warnings can be suppressed by explicitly specifying measure
+eltypes will work, so long as there are only two classes (levels). However, you may get
+warnings that mitigate possible misinterpretations of results (e.g., about which class is
+the "positive" one). Some warnings can be suppressed by explicitly specifying measure
 parameters, such as `levels`.
 
 To be 100% safe and avoid warnings, use data with the recommended observation scitype.

--- a/src/StatisticalMeasures.jl
+++ b/src/StatisticalMeasures.jl
@@ -2,7 +2,7 @@ module StatisticalMeasures
 
 using Statistics
 using MacroTools
-import CategoricalArrays
+using CategoricalArrays
 using CategoricalDistributions
 using OrderedCollections
 using ScientificTypesBase

--- a/src/confusion_matrices.jl
+++ b/src/confusion_matrices.jl
@@ -228,7 +228,7 @@ function ConfusionMatrix(
     dic::AbstractDict;
     checks=true,
     ordered=false,
-    ) 
+    )
     ConfusionMatrix(m, freeze(dic); checks, ordered)
 end
 
@@ -323,6 +323,12 @@ import Base.(*)
 
 Return the levels associated with the confusion matrix `m`, in the order consistent with
 the regular matrix returned by `$CM.matrix(cm)`.
+
+!!! note New in StatisticalMeasures 0.3
+
+    For confusion matrices constructed using `CategoricalArray`s, a `CategoricalVector` is
+    returned. Previously the levels were unwrapped, to match the old behavior of
+    `CategoricalArrays.levels`.
 
 """
 CategoricalArrays.levels(cm::ConfusionMatrix) =
@@ -568,7 +574,7 @@ function Base.show(stream::IO, m::MIME"text/plain", cm::ConfusionMatrix{N}
     mincw    = ceil(Int, 12/N)
     cw       = max(length(string(maximum(cm.mat))),maximum(length.(labels)),mincw)
     textlim  = 9
-    firstcw  = max(length(string(maximum(cm.mat))),maximum(length.(labels)),textlim)    
+    firstcw  = max(length(string(maximum(cm.mat))),maximum(length.(labels)),textlim)
     totalwidth = firstcw + cw * N + N + 2
     width < totalwidth && (show(stream, m, cm.mat); return)
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,7 +3,7 @@
     wts = rand(3)
     class_wts = Dict('a'=> 2, 'b'=> 3)
     y2 = CategoricalArrays.categorical(collect("aba"), ordered=true)
-    yhat2 = UnivariateFinite(CategoricalArrays.levels(y2), rand(3), augment=true, pool=y2)
+    yhat2 = UnivariateFinite(CategoricalArrays.levels(y2), rand(3), augment=true)
     @compile_workload begin
         MultitargetLPLoss()(y, y)
         MultitargetLPLoss()(y, y, wts)

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -60,7 +60,7 @@ struct _AreaUnderCurve  end
 function (::_AreaUnderCurve)(ŷ::AbstractArray{<:UnivariateFinite}, y)
 
     # actually this choice theoretically does not matter:
-    positive_class = CategoricalDistributions.classes(first(ŷ))|> last
+    positive_class = CategoricalArrays.levels(first(ŷ))|> last
     scores = pdf.(ŷ, positive_class)
 
     return Functions.auc(scores, y, positive_class)
@@ -263,7 +263,7 @@ struct BrierScoreOnScalars  end
 
 # finite case:
 @inline function (measure::BrierScoreOnScalars)(ŷ::UnivariateFinite, y)
-    levels = CategoricalDistributions.classes(ŷ)
+    levels = CategoricalArrays.levels(ŷ)
     pvec = broadcast(pdf, ŷ, levels)
     offset = 1 + sum(pvec.^2)
     return 2 * pdf(ŷ, y) - offset
@@ -286,7 +286,7 @@ function (measure::_BrierScoreType)(
     y::NonMissingCatArrOrSub,
     weight_args...,
     )
-    probs = pdf(ŷ, CategoricalDistributions.classes(first(ŷ)))
+    probs = pdf(ŷ, CategoricalArrays.levels(first(ŷ)))
     offset = 1 .+ vec(sum(probs.^2, dims=2))
     unweighted = 2 .* broadcast(pdf, ŷ, y) .- offset
     aggregate(unweighted, weights = API.CompositeWeights(y, weight_args...))
@@ -297,7 +297,7 @@ function API.measurements(
     y::NonMissingCatArrOrSub,
     weight_args...,
     )
-    probs = pdf(ŷ, CategoricalDistributions.classes(first(ŷ)))
+    probs = pdf(ŷ, CategoricalArrays.levels(first(ŷ)))
     offset = 1 .+ vec(sum(probs.^2, dims=2))
     unweighted = 2 .* broadcast(pdf, ŷ, y) .- offset
     API.weighted(unweighted, weights = API.CompositeWeights(y, weight_args...))
@@ -440,7 +440,7 @@ end
     y,
     )
     α = measure.alpha
-    levels = CategoricalDistributions.classes(ŷ)
+    levels = CategoricalArrays.levels(ŷ)
     probs = broadcast(pdf, ŷ, levels)
     return (pdf(ŷ, y)/norm(probs, α))^(α - 1)
 end
@@ -465,7 +465,7 @@ _norm(A::AbstractArray{<:Any,N}, α) where N =
 function unweighted(measure::_SphericalScoreType, ŷ, y)
     α = measure.alpha
     alphanorm(A) = _norm(A, α)
-    predicted_probs = pdf(ŷ, CategoricalDistributions.classes(first(ŷ)))
+    predicted_probs = pdf(ŷ, CategoricalArrays.levels(first(ŷ)))
     (broadcast(pdf, ŷ, y) ./ alphanorm(predicted_probs)).^(α - 1)
 end
 (measure::_SphericalScoreType)(

--- a/src/roc.jl
+++ b/src/roc.jl
@@ -7,11 +7,11 @@ const ERR_NEED_CATEGORICAL = ArgumentError(
 )
 
 const ERR_ROC1 = ArgumentError(
-    "probabilistic predictions should be for exactly two classes"
+    "probabilistic predictions should be for exactly two classes (levels)"
 )
 
 const ERR_ROC2 = ArgumentError(
-    "ground truth observations must have exactly two classes in the pool"
+    "ground truth observations must have exactly two classes (levels) in the pool"
 )
 
 # perform some argument checks and return the ordered levels:

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -34,6 +34,8 @@ snakecase(s::Symbol) = Symbol(snakecase(string(s)))
 """
     check_pools(A::UnivariateFiniteArray, B::CategoricalArrays.CatArrOrSub)
 
+*Private method.*
+
 Check that the class pool of `A` coincides with the class pool of `B`, as sets. If both
 `A` and `B` are ordered, check the pools have the same ordering.
 
@@ -45,8 +47,10 @@ function API.check_pools(
     B::CategoricalArrays.CatArrOrSub,
     )
 
-    classes_a = CategoricalDistributions.classes(A)
-    classes_b = CategoricalDistributions.classes(B)
+    first_nonmissing_index = findfirst(x->!ismissing(x), A)
+    element_of_A = A[first_nonmissing_index]
+    classes_a = CategoricalArrays.levels(element_of_A)
+    classes_b = CategoricalArrays.levels(B)
     if  CategoricalArrays.isordered(A) && CategoricalArrays.isordered(B)
         classes_a == classes_b || throw(API.ERR_POOL_ORDER)
     else

--- a/test/ScientificTypesExt.jl
+++ b/test/ScientificTypesExt.jl
@@ -19,7 +19,7 @@ ms = measures(that, t)
 end
 
 y = categorical(rand("ab", n))
-yhat = UnivariateFinite(levels(y), rand(n), augment=true, pool=y)
+yhat = UnivariateFinite(levels(y), rand(n), augment=true)
 ms2 = measures((yhat, y))
 @test all(ms2) do (_, metadata)
     Multiclass{2} <: metadata.observation_scitype &&

--- a/test/confusion_matrices.jl
+++ b/test/confusion_matrices.jl
@@ -1,4 +1,24 @@
+import StatisticalMeasuresBase as API
+using StatisticalMeasures
+using Test
+using ScientificTypes
+import ScientificTypes as ST
+using Statistics
+using CategoricalArrays
+import StableRNGs.StableRNG
+using MLUtils
+using OrderedCollections
+using CategoricalDistributions
+using LinearAlgebra
+import Distributions
+
 const CM = StatisticalMeasures.ConfusionMatrices
+
+# because tests were developed before measures were required to be directly callable and
+# before `call` was removed from StatisticalMeasuresBase:
+call(m, args...) = m(args...)
+
+srng(n=123) = StableRNG(n)
 
 @testset "constructors, `matrix`, equality, element access, arithmetic" begin
     m = [1 2; 3 4]
@@ -46,7 +66,7 @@ end
     ŷraw = [missing, 'f', 'f', 'm', 'f',     'f', 'n', 'm', 'n', 'm', 'f']
     y = categorical(yraw)
     ŷ = categorical(ŷraw)
-    l = levels(y) # f, m, n
+    l = levels(y) # f, m, n (`CategoricalValue`s)
     cm = CM.confmat(ŷ, y)
     ẑ, z = StatisticalMeasures.StatisticalMeasuresBase.skipinvalid(ŷ, y)
     e(c1, c2) = sum((ẑ .== c1) .& (z .== c2))
@@ -58,7 +78,7 @@ end
     @test cm2 == cm
 
     perm = [3, 1, 2]
-    l2 = l[perm]
+    @test l[perm] == ['n', 'f', 'm']
     cm2 = CM.confmat(ŷ, y; perm=perm)
     @test cm2 == cm
     @test levels(cm2) == l[perm]
@@ -174,7 +194,7 @@ end
     # set invalid levels:
     cm = ConfusionMatrix(levels=[1, 2])
     @test_throws(
-       StatisticalMeasures.ConfusionMatrices. ERR_ORPHANED_OBSERVATIONS,
+       StatisticalMeasures.ConfusionMatrices.ERR_ORPHANED_OBSERVATIONS,
        cm(y1, y2),
     )
 end

--- a/test/confusion_matrices.jl
+++ b/test/confusion_matrices.jl
@@ -14,12 +14,6 @@ import Distributions
 
 const CM = StatisticalMeasures.ConfusionMatrices
 
-# because tests were developed before measures were required to be directly callable and
-# before `call` was removed from StatisticalMeasuresBase:
-call(m, args...) = m(args...)
-
-srng(n=123) = StableRNG(n)
-
 @testset "constructors, `matrix`, equality, element access, arithmetic" begin
     m = [1 2; 3 4]
     index_given_level = Dict("A" => 1, "B" => 2)

--- a/test/probabilistic.jl
+++ b/test/probabilistic.jl
@@ -34,8 +34,8 @@
     ŷ2 = UnivariateFinite(y2[1:2], probs, augment=true)
     # check positive class has changed:
     @test levels(y) != levels(y2)
-    @test CategoricalDistributions.classes(ŷ) !=
-        CategoricalDistributions.classes(ŷ2)
+    @test CategoricalArrays.levels(ŷ) !=
+        CategoricalArrays.levels(ŷ2)
     # check probability assignments are not changed:
     @test pdf.(ŷ, "pos") == pdf.(ŷ2, "pos")
     # test auc is the same:
@@ -95,7 +95,7 @@ end
     #    [[.1, .9], [.9, .1], [.8, .2], [.35, .65], [0.2, 0.8], [0.3,0.7]])
     # 0.6130097025803921
     y2 = categorical(["spam", "ham", "ham", "spam", "ham", "ham"])
-    L2 = CategoricalDistributions.classes(y2[1])
+    L2 = CategoricalArrays.levels(y2[1])
     probs = vcat([.1 .9], [.9 .1], [.8 .2], [.35 .65], [0.2 0.8], [0.3 0.7])
     yhat2 = UnivariateFinite(L2, probs)
     y2m = vcat(y2, [missing,])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ call(m, args...) = m(args...)
 
 srng(n=123) = StableRNG(n)
 
+@testset "tools.jl" begin
+    include("tools.jl")
+end
+
 @testset "functions.jl" begin
     include("functions.jl")
 end

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -1,0 +1,12 @@
+using CategoricalDistributions
+import StatisticalMeasuresBase as API
+
+@testset "check_pools" begin
+    y = categorical(collect("aba"), ordered=true)
+    yhat = UnivariateFinite(levels(y), rand(3), augment=true)
+    y = [y..., missing]
+    yhat = [yhat..., missing]
+    @test isnothing(API.check_pools(yhat, y))
+end
+
+true


### PR DESCRIPTION
In this PR we:

- Bump the CategoricalArrays requirement to 1.0
- (**mildly breaking**) Arrange that StatisticalMeasures' extension of the `CategoricalArrays.levels` to confusion matrices mimics the new behavior: it returns a `CategoricalVector`, not an unwrapped version of the same.
