### PR TITLE
Fix edge case average precision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatisticalMeasures"
 uuid = "a19d573c-0a75-4610-95b3-7071388c7541"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,9 @@ In addition to the measures themselves, this package provides:
 
 - A tool [`roc_curve`](@ref) for plotting Receiver Operator Characteristics
 
+- A tool [`precision_recall_curve`](@ref) for plotting precision-recall curves (more
+  informative alternative to `roc_curve` for unbalanced data)
+
 - An extension module allowing measures from
   [LossFunctions.jl](https://github.com/JuliaML/LossFunctions.jl) to be used and extended
   using the same syntax as other measures. See [Using losses from LossFunctions.jl](@ref).

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -307,6 +307,11 @@ In some other implementations, such as
 for unit recall, in the case the predicted positive class probabilities exclude `1.0`, and
 this is avoided here.
 
+## Edge-case exception
+
+If every predicted probability is the same (``k=1'') then the returned average precision
+is zero.
+
 """
 
 """
@@ -323,10 +328,13 @@ $DOC_AVERAGE_PRECISION
 $DOC_CONFUSION_CHECK Method requires at least one observation, but this is not checked.
 
 """
-function average_precision(ŷ, y, positive_class)
+function average_precision(ŷ::AbstractArray{<:T}, y, positive_class) where T
 
     recalls, precisions, _ = precision_recall_curve(ŷ, y, positive_class)
-    area = 0.0
+    area = zero(T)
+
+    # if ŷ is constant, return zero;;;;;
+    length(recalls) ≤ 2 && return area
 
     # `recalls` will have length at least two:
     length(recalls) > 2 || return 1.0

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -65,6 +65,13 @@ end
     area_deltas = precisions[1:(end -1)] .* recall_deltas
     area = sum(area_deltas)
     @test Functions.average_precision(ŷ2, y, "1") ≈ area
+
+    # edge case: only one recall/precision
+    # (https://github.com/JuliaAI/StatisticalMeasures.jl/issues/97)
+    ŷ3 = fill(0.123, length(y))
+    recalls, precisions, thresholds = Functions.precision_recall_curve(ŷ3, y, "1")
+    @test thresholds == [0.123,]
+    @test Functions.average_precision(ŷ3, y, "1") == 0.0
 end
 
 @testset "AUC" begin


### PR DESCRIPTION
Addresses #97 by setting `average_precision(yhat, y, ...) = 0` if `yhat` is constant.